### PR TITLE
New function find_parents on element

### DIFF
--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -655,6 +655,37 @@ class TestElement(TestCase):
         lis = parent_obj.findall('subtag')
         self.assertEqual(lis, [obj])
 
+    def test_find_parents(self):
+        """Testing find_parents
+        """
+        parent_obj = self.cls()
+        obj1 = self.sub_cls()
+        obj2 = self.sub_cls()
+        obj3 = self.sub_cls()
+        # define tree, we need to set _parent by hand because we don't have dtd
+        parent_obj.subtag = obj1
+        obj1._parent = parent_obj
+        obj1.subtag = obj2
+        obj2._parent = obj1
+        obj2.subtag = obj3
+        obj3._parent = obj2
+
+        # no parent
+        lis = parent_obj.find_parents('subtag')
+        self.assertEqual(lis, [])
+
+        # element matches
+        lis = obj1.find_parents('subtag')
+        self.assertEqual(lis, [obj1])
+
+        # one parent (and self)
+        lis = obj2.find_parents('subtag')
+        self.assertEqual(lis, [obj2, obj1])
+
+        # 2 parents (and self)
+        lis = obj3.find_parents('subtag')
+        self.assertEqual(lis, [obj3, obj2, obj1])
+
     def test_write(self):
         filename = 'tests/test.xml'
         self.assertFalse(os.path.isfile(filename))

--- a/xmltool/elements.py
+++ b/xmltool/elements.py
@@ -370,6 +370,21 @@ class Element(object):
                 lis += [elt]
         return lis
 
+    def find_parents(self, tagname):
+        """Find all parents named tagname in element's parents
+
+        :param tagname: (str) The tagname to look for
+        :returns: (list) List of matching parents, ordered from the inside to
+            the outside. This will return the object himself as first element
+            if its tagname is the one we're looking for
+        """
+        res = []
+        if self._tagname == tagname:
+            res = [self]
+        if self._parent is not None:
+            res += self._parent.find_parents(tagname)
+        return res
+
     def write(self, filename=None, encoding=None, dtd_url=None, validate=True,
               transform=None):
         filename = filename or self._xml_filename


### PR DESCRIPTION
Finds all parents matching given tagname.
We return them for the closest parent to the document root.
